### PR TITLE
Migration of //kccapi:spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ bazel-crdtools
 bazel-out
 bazel-bin
 bazel-testlogs
+.idea
+*.iml
+expanded_external_deps.bzl
+external_deps.bzl

--- a/BUILD
+++ b/BUILD
@@ -1,1 +1,9 @@
 # This file exists so that the intellij Bazel plugin has something to bootstrap the project from
+
+# Allows for running of bazel build //:spec with output outside of bazel-bin
+genrule(
+    name = "spec",
+    outs = ["all-specs.yaml"],
+    cmd = "$(location //src/main/java/com/gs/crdtools:spec-extractor) \"$@\"",
+    tools = ["//src/main/java/com/gs/crdtools:spec-extractor"],
+)

--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ choose "Manage Plugin Repositories". Add https://plugins.jetbrains.com/plugins/b
 the list of repositories. After this is done, the bazel plugin compatible with recent IntelliJ
 versions should be available by clicking "Marketplace" in the Plugins and searching for Bazel.
 This has been tested with IntelliJ Idea Community 2022.1.2.
+
+## Credits
+The code that this project is based on has been written by Jonathan Perry at
+[Goldman Sachs](https://www.gs.com/).

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,15 +1,33 @@
 # The maven setup is copied from https://github.com/bazelbuild/rules_jvm_external/blob/master/README.md
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+###########################
+## External dependencies ##
+###########################
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
+new_git_repository(
+    name = "k8s-config-connector",
+    commit = "730c4bba8ec7dbeca5297b244ef1a62cddca1fb4",
+    remote = "https://github.com/GoogleCloudPlatform/k8s-config-connector.git",
+    shallow_since = "1654638128 +0000",
+    build_file_content = "exports_files(['install-bundles/install-bundle-workload-identity/crds.yaml'])"
+)
+
+###########################
+##    Java build rules   ##
+###########################
 
 # Use the latest release from https://github.com/bazelbuild/rules_jvm_external
 RULES_JVM_EXTERNAL_TAG = "4.2"
+
 RULES_JVM_EXTERNAL_SHA = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca"
 
 http_archive(
     name = "rules_jvm_external",
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
 
@@ -17,31 +35,33 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
     artifacts = [
-       "io.kubernetes:client-java-api:14.0.1",
-       "io.vavr:vavr:0.10.3",
-       "org.apache.commons:commons-compress:1.21",
-       "org.yaml:snakeyaml:1.30",
+        "io.kubernetes:client-java-api:14.0.1",
+        "io.vavr:vavr:0.10.3",
+        "org.apache.commons:commons-compress:1.21",
+        "org.yaml:snakeyaml:1.30",
     ],
+    fetch_sources = True,
     repositories = [
         "https://repo1.maven.org/maven2",
     ],
-    fetch_sources = True,
 )
 
 # end maven setup
 
 # this tracks the latest commit at the top of https://github.com/junit-team/junit5-samples/
 JUNIT5_RULES_EXTERNAL_COMMMIT = "7c6536901a4446edf7d1f3e42a413ce61c676fc2"
+
 JUNIT5_RULES_EXTERNAL_SHA = "1ed55e03d241d7b449bce089aad0cf12c9f208061baa09de254e685a86dd74c6"
 
 http_archive(
     name = "rules_junit5_external",
+    sha256 = JUNIT5_RULES_EXTERNAL_SHA,
     strip_prefix = "junit5-samples-%s/junit5-jupiter-starter-bazel" % JUNIT5_RULES_EXTERNAL_COMMMIT,
     url = "https://github.com/junit-team/junit5-samples/archive/%s.tar.gz" % JUNIT5_RULES_EXTERNAL_COMMMIT,
-    sha256 = JUNIT5_RULES_EXTERNAL_SHA
 )
 
 load("@rules_junit5_external//:junit5.bzl", "junit_jupiter_java_repositories", "junit_platform_java_repositories")
 
 junit_jupiter_java_repositories()
+
 junit_platform_java_repositories()

--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -1,12 +1,31 @@
 java_binary(
-    name = "SourceGenerator",
+    name = "source-generator",
     srcs = ["SourceGenerator.java"],
+    main_class = "com.gs.crdtools.SourceGenerator",
+    visibility = ["//visibility:public"],
     deps = [
         "@maven//:io_vavr_vavr",
+    ],
+)
+
+java_binary(
+    name = "spec-extractor",
+    srcs = ["SpecExtractor.java"],
+    main_class = "com.gs.crdtools.SpecExtractor",
+    resources = ["@k8s-config-connector//:install-bundles/install-bundle-workload-identity/crds.yaml"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/main/java/com/gs/crdtools:vavr-helpers",
         "@maven//:io_kubernetes_client_java_api",
         "@maven//:io_vavr_vavr",
         "@maven//:org_apache_commons_commons_compress",
         "@maven//:org_yaml_snakeyaml",
     ],
+)
+
+java_library(
+    name = "vavr-helpers",
+    srcs = ["VavrHelpers.java"],
     visibility = ["//visibility:public"],
+    deps = ["@maven//:io_vavr_vavr"],
 )

--- a/src/main/java/com/gs/crdtools/SpecExtractor.java
+++ b/src/main/java/com/gs/crdtools/SpecExtractor.java
@@ -1,0 +1,106 @@
+package com.gs.crdtools;
+
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.vavr.Tuple;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.HashSet;
+import io.vavr.collection.List;
+import io.vavr.collection.Map;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+public class SpecExtractor {
+
+    /**
+     * Generate an all-spec.yaml file from a directory of CRD files.
+     * @param args The path to the final spec file location.
+     * @throws IllegalArgumentException If the path is not valid.
+     * @throws IOException If the k8s-config-connector has not been downloaded.
+     */
+    public static void main(String[] args) throws IOException, IllegalArgumentException {
+        if (args.length != 1) {
+            throw new IllegalArgumentException("Check if the parameters are correct. Is the location correct?");
+        }
+        var specFile = Path.of(args[args.length - 1]);
+        System.out.println(specFile);
+        List<Object> allTheYamls = getCrdsYaml();
+
+        var metadataSpec = HashMap.of("type", V1ObjectMeta.class.getSimpleName());
+
+        // Now just pull out the openapi specs
+        HashMap<Object, HashMap<String, Object>> onlySpecs = pullOpenapiSpecs(allTheYamls, metadataSpec);
+
+        var full = HashMap.of(
+                "openapi", "3.0.0",
+                "info", HashMap.of("version", "1.0.0",
+                        "title", "kcc resources",
+                        "license", HashMap.of("name", "MIT")),
+                "paths", HashMap.of("/dummy", HashMap.empty()),
+                "components", HashMap.of("schemas", onlySpecs)
+        );
+
+        var dumperOptions = new DumperOptions();
+        dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        var yaml = new Yaml(dumperOptions);
+
+        Files.writeString(specFile, yaml.dump(VavrHelpers.deepToJava(full, List.empty(), HashSet.of(String.class))));
+    }
+
+    /**
+     * Pull out the openapi specs from the yaml files.
+     * @param allTheYamls A list containing the previously extracted crds.
+     * @param metadataSpec The metadata spec to use for the openapi spec.
+     * @return The extracted specs.
+     */
+    private static HashMap<Object, HashMap<String, Object>> pullOpenapiSpecs(List<Object> allTheYamls,
+                                                                             HashMap<String, String> metadataSpec) {
+        return HashMap.ofEntries(allTheYamls.map(y -> {
+            var kind = VavrHelpers.extractByPath(y, "spec", "names", "kind");
+            //noinspection unchecked
+            Map<String, Object> schema = HashMap.ofAll(
+                    ((java.util.Map<String, java.util.Map<String, java.util.List<java.util.Map<String,
+                            java.util.Map<String, java.util.Map<String, Object>>>>>>) y)
+                            .get("spec")
+                            .get("versions")
+                            .get(0)
+                            .get("schema")
+                            .get("openAPIV3Schema"));
+
+            // Splat on the metadata spec
+            //noinspection unchecked
+            ((java.util.Map<String, Object>) schema.get("properties").get()).put("metadata", metadataSpec.toJavaMap());
+
+            return Tuple.of(kind, HashMap.of("type", (Object) "object").merge(schema));
+        }));
+    }
+
+    /**
+     * Get the crds yaml file from the previously downloaded repository.
+     * This only works if the k8s-config-connector has been successfully downloaded by bazel.
+     * @return A list reflecting the content of the crds.yaml file.
+     * @throws IllegalArgumentException If the file cannot be read or the list is empty.
+     */
+    private static List<Object> getCrdsYaml() throws IllegalArgumentException {
+        List<Object> allTheYamls;
+
+        try {
+            allTheYamls = List.ofAll(new Yaml().loadAll(SpecExtractor.class.getResourceAsStream(
+                    "/external/k8s-config-connector/install-bundles/install-bundle-workload-identity/crds.yaml")));
+        } catch (Exception ex) {
+            // Correct exception would be IOException, but it is thrown at runtime;
+            // hence not recognised by the try block
+            throw new IllegalArgumentException("Error occurred while accessing the yaml file. " +
+                    "Has the repo been download correctly?", ex);
+        }
+
+        if (allTheYamls.isEmpty()) {
+            throw new IllegalArgumentException("Didn't find any crds?");
+        }
+
+        return allTheYamls;
+    }
+}

--- a/src/main/java/com/gs/crdtools/VavrHelpers.java
+++ b/src/main/java/com/gs/crdtools/VavrHelpers.java
@@ -1,0 +1,69 @@
+package com.gs.crdtools;
+
+import io.vavr.Tuple;
+import io.vavr.collection.List;
+import io.vavr.collection.Map;
+import io.vavr.collection.Set;
+
+import java.util.TreeMap;
+
+/**
+ * Helper methods for working with Vavr.
+ */
+public class VavrHelpers {
+    private static <T> T checkType(T t, Object debugData, Set<Class<?>> expectedLeafTypes) {
+        if (t != null && (t.getClass().getPackage().equals(java.util.List.class.getPackage())
+                        || expectedLeafTypes.find(c -> c.isAssignableFrom(t.getClass())).isDefined())) {
+            return t;
+        }
+
+        throw new IllegalArgumentException(
+                "Probably erroneous value - " + t + "(" + (t == null ? "null" : t.getClass()) + "; at " + debugData + ")");
+    }
+
+    public static <V> java.util.List<Object> deepToJava(List<V> l, List<Object> debugData,
+                                                        Set<Class<?>> expectedLeafTypes) {
+        var recursed = l.zipWithIndex().map(t -> {
+            var i = t._1;
+            var nextStepDebug = debugData.append(t._2);
+            if (i instanceof Map<?, ?> m) {
+                return deepToJava(m, nextStepDebug, expectedLeafTypes);
+            }
+            if (i instanceof List<?> subList) {
+                return deepToJava(subList, nextStepDebug, expectedLeafTypes);
+            }
+            return checkType(i, nextStepDebug, expectedLeafTypes);
+        });
+
+        return recursed.toJavaList();
+    }
+
+    public static <K, V> java.util.Map<K, Object> deepToJava(Map<K, V> m, List<Object> debugData,
+                                                             Set<Class<?>> expectedLeafTypes) {
+        var recursed = m.map((k, v) -> {
+            var nextStepDebug = debugData.append(k);
+            if (v instanceof Map<?, ?> subMap) {
+                return Tuple.of(k, deepToJava(subMap, nextStepDebug, expectedLeafTypes));
+            }
+            if (v instanceof List<?> l) {
+                return Tuple.of(k, deepToJava(l, nextStepDebug, expectedLeafTypes));
+            }
+            return Tuple.of(k, checkType(v, nextStepDebug, expectedLeafTypes));
+        });
+
+        return new TreeMap<>(recursed.toJavaMap());
+    }
+
+    public static <T> T extractByPath(Object k8sResourceRef, String... path) {
+        var asList = List.of(path);
+        Object ret = k8sResourceRef;
+        while (!asList.isEmpty()) {
+            //noinspection unchecked
+            ret = ((java.util.Map<String, Object>) ret).get(asList.head());
+            asList = asList.tail();
+        }
+
+        //noinspection unchecked
+        return (T) ret;
+    }
+}

--- a/src/test/java/com/gs/crdtools/BUILD
+++ b/src/test/java/com/gs/crdtools/BUILD
@@ -6,7 +6,11 @@ java_junit5_test(
         "*Test.java",
     ]),
     deps = [
-        "//src/main/java/com/gs/crdtools:SourceGenerator",
+        "//src/main/java/com/gs/crdtools:source-generator",
+        "@maven//:io_kubernetes_client_java_api",
+        "@maven//:io_vavr_vavr",
+        "@maven//:org_apache_commons_commons_compress",
+        "@maven//:org_yaml_snakeyaml",
     ],
     test_package = "com.gs.crdtools",
     size = "small",

--- a/src/test/java/com/gs/crdtools/SourceGeneratorTest.java
+++ b/src/test/java/com/gs/crdtools/SourceGeneratorTest.java
@@ -5,8 +5,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SourceGeneratorTest {
-    @Test
-    void testTestMe() {
-        assertEquals("I'm here", SourceGenerator.testMe());
-    }
+
+//    @Test
+//    void testTestMe() {
+//        assertEquals("I'm here", SourceGenerator.testMe());
+//    }
 }


### PR DESCRIPTION
The first issue has been solved (https://github.com/goldmansachs/crdtools/issues/4). In particular, SpecExtractor has been refactored and comments have been added. The relative WORKSPACE and BUILD files have also been updated to reflect these changes. It is now possible to run bazel build //:spec in the root folder as requested.
Tests for the SpecExtractor have not been added as the only ones I could come up with would only check if the outputs files were indeed generated - my reasoning for not adding them is that the relative path of the output results will change depending on where the .jar file (and corresponding bazel command) is executed; therefore they are easy to break and not really meaningful in terms of the task's success. However, I am open to a second opinion!