### PR TITLE
Add template codegen overloading, split into separate package

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,6 +45,7 @@ maven_install(
         "io.swagger.codegen.v3:swagger-codegen-generators:1.0.34",
         "io.swagger.parser.v3:swagger-parser-v3:2.1.1",
         "io.swagger.core.v3:swagger-models:2.2.1",
+        "com.github.jknack:handlebars:4.3.0",
     ],
     # The rules_jvm_external, when adding the swagger dependencies, downloads
     # a version of atlassian that comes under a different name. This is a

--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -35,21 +35,6 @@ java_library(
     deps = ["@maven//:io_vavr_vavr"],
 )
 
-java_library(
-    name = "swagger-codegen",
-    srcs = ["MyCodegen.java"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//src/main/java/com/gs/crdtools:base-object",
-        "@maven//:io_kubernetes_client_java_api",
-        "@maven//:io_swagger_codegen_v3_swagger_codegen",
-        "@maven//:io_swagger_codegen_v3_swagger_codegen_generators",
-        "@maven//:io_swagger_core_v3_swagger_models",
-        "@maven//:io_swagger_parser_v3_swagger_parser_v3",
-        "@maven//:io_vavr_vavr",
-    ],
-)
-
 java_binary(
     name = "gen-source-from-spec",
     srcs = ["SourceGenFromSpec.java"],
@@ -64,7 +49,7 @@ java_binary(
     deps = [
         "//src/main/java/com/gs/crdtools:spec-extractor",
         "//src/main/java/com/gs/crdtools:vavr-helpers",
-        "//src/main/java/com/gs/crdtools:swagger-codegen",
+        "//src/main/java/com/gs/crdtools/codegen:swagger-codegen-extensions",
         "//src/main/java/com/gs/crdtools:openapi-src-genner",
         "@maven//:io_swagger_codegen_v3_swagger_codegen",
         "@maven//:io_kubernetes_client_java_api",

--- a/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
+++ b/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
@@ -1,5 +1,6 @@
 package com.gs.crdtools;
 
+import com.gs.crdtools.codegen.CrdtoolsCodegen;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.swagger.codegen.v3.DefaultGenerator;
 import io.swagger.codegen.v3.config.CodegenConfigurator;
@@ -49,12 +50,12 @@ public class SourceGenFromSpec {
      * @param out The output path.
      * @throws IOException If any error occurs while loading the given paths.
      */
-    private static void generateSourceCodeFromSpecs(String specs, Path out) throws IOException {
+    public static void generateSourceCodeFromSpecs(String specs, Path out) throws IOException {
         var tmpOutputDir = Files.createTempDirectory("openAPIGen");
 
         var cc = new CodegenConfigurator()
                 .setInputSpec(specs)
-                .setLang(MyCodegen.class.getCanonicalName())
+                .setLang(CrdtoolsCodegen.class.getCanonicalName())
                 .setOutputDir(tmpOutputDir.toAbsolutePath().toString())
                 .setModelPackage("kccapi")
                 // CodegenConfigurator modifies its Map arguments, so we need to wrap it in something mutable

--- a/src/main/java/com/gs/crdtools/codegen/BUILD
+++ b/src/main/java/com/gs/crdtools/codegen/BUILD
@@ -1,0 +1,20 @@
+java_library(
+    name = "swagger-codegen-extensions",
+    srcs = [
+        "CrdtoolsCodegen.java",
+        "CustomOverrideTemplateEngine.java",
+        "OverrideTemplateLoader.java",
+    ],
+    visibility = ["//visibility:public"],
+    resources = ["//src/main/resources:all"],
+    deps = [
+        "//src/main/java/com/gs/crdtools:base-object",
+        "@maven//:io_kubernetes_client_java_api",
+        "@maven//:io_swagger_codegen_v3_swagger_codegen",
+        "@maven//:io_swagger_codegen_v3_swagger_codegen_generators",
+        "@maven//:io_swagger_core_v3_swagger_models",
+        "@maven//:io_swagger_parser_v3_swagger_parser",
+        "@maven//:io_vavr_vavr",
+        "@maven//:com_github_jknack_handlebars",
+    ],
+)

--- a/src/main/java/com/gs/crdtools/codegen/CrdtoolsCodegen.java
+++ b/src/main/java/com/gs/crdtools/codegen/CrdtoolsCodegen.java
@@ -1,15 +1,22 @@
-package com.gs.crdtools;
+package com.gs.crdtools.codegen;
 
+import com.gs.crdtools.BaseObject;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.swagger.codegen.v3.CodegenModel;
+import io.swagger.codegen.v3.CodegenProperty;
 import io.swagger.codegen.v3.generators.java.SpringCodegen;
 import io.swagger.v3.oas.models.media.Schema;
 import io.vavr.collection.List;
 
 /**
- * This class defines the specific implementation of the CodeGenerator.
+ * An extension of SpringCodegen with some custom functionality.
  */
-public class MyCodegen extends SpringCodegen {
+public class CrdtoolsCodegen extends SpringCodegen {
+    @Override
+    public void processOpts() {
+        super.processOpts();
+        templateEngine = new CustomOverrideTemplateEngine(this);
+    }
 
     /**
      * Create a new instance of a model from existing schemas.

--- a/src/main/java/com/gs/crdtools/codegen/CustomOverrideTemplateEngine.java
+++ b/src/main/java/com/gs/crdtools/codegen/CustomOverrideTemplateEngine.java
@@ -1,0 +1,50 @@
+package com.gs.crdtools.codegen;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.io.TemplateLoader;
+import com.gs.crdtools.codegen.OverrideTemplateLoader;
+import io.swagger.codegen.v3.CodegenConfig;
+import io.swagger.codegen.v3.templates.HandlebarTemplateEngine;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A customisation of HandlebarTemplateEngine that will construct a template with
+ * an OverrideTemplateLoader instead of the default CodegenTemplateLoader.
+ */
+class CustomOverrideTemplateEngine extends HandlebarTemplateEngine {
+    private final CodegenConfig config;
+
+    // copied from
+    public CustomOverrideTemplateEngine(CodegenConfig config) {
+        super(config);
+        this.config = config;
+    }
+
+    // copied from https://github.com/swagger-api/swagger-codegen/blob/fcd24e736c513fbb5d08cd7362b01088b4942096/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/HandlebarTemplateEngine.java
+    @Override
+    public String getRendered(String templateFile, Map<String, Object> templateData) throws IOException {
+        Template hTemplate = this.getHandlebars(templateFile);
+        return hTemplate.apply(templateData);
+    }
+
+    // copied from https://github.com/swagger-api/swagger-codegen/blob/fcd24e736c513fbb5d08cd7362b01088b4942096/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/HandlebarTemplateEngine.java
+    // with the change that OverrideTemplateLoader is used instead of CodegenTemplateLoader
+    private Template getHandlebars(String templateFile) throws IOException {
+        templateFile = templateFile.replace("\\", "/");
+        final String templateDir = config.templateDir().replace("\\", "/");
+        final TemplateLoader templateLoader;
+        String customTemplateDir = config.customTemplateDir() != null ? config.customTemplateDir().replace("\\", "/") : null;
+        // this is the line that differs from upstream
+        templateLoader = new OverrideTemplateLoader()
+                .templateDir(templateDir)
+                .customTemplateDir(customTemplateDir);
+        final Handlebars handlebars = new Handlebars(templateLoader);
+        handlebars.prettyPrint(true);
+        config.addHandlebarHelpers(handlebars);
+        return handlebars.compile(templateFile);
+    }
+
+}

--- a/src/main/java/com/gs/crdtools/codegen/OverrideTemplateLoader.java
+++ b/src/main/java/com/gs/crdtools/codegen/OverrideTemplateLoader.java
@@ -1,0 +1,30 @@
+package com.gs.crdtools.codegen;
+
+import io.swagger.codegen.v3.templates.CodegenTemplateLoader;
+
+import java.nio.file.Path;
+
+/**
+ * A CodegenTemplateLoader that for each attempt to resolve a template will check
+ * for an overloaded version of the template in the classpath and return a reference
+ * to that if it exists, otherwise fall back to the original behaviour.
+ */
+class OverrideTemplateLoader extends CodegenTemplateLoader {
+    private static final String OVERRIDE_CLASSPATH_PREFIX = "/swaggerTemplateOverloads";
+
+    @Override
+    public String resolve(String uri) {
+        if (!uri.endsWith(this.getSuffix())) {
+            uri = uri + this.getSuffix();
+        }
+
+        var overridePath = Path.of(OVERRIDE_CLASSPATH_PREFIX, uri).toString();
+        var resource = this.getClass().getClassLoader().getResource(overridePath);
+        if (resource != null) {
+            return overridePath;
+        }
+
+        return super.resolve(uri);
+    }
+
+}

--- a/src/main/resources/BUILD
+++ b/src/main/resources/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "all",
+    srcs = glob(["swaggerTemplateOverloads/**"]),
+    visibility = ["//visibility:public"],
+)

--- a/src/main/resources/swaggerTemplateOverloads/generatedAnnotation.mustache
+++ b/src/main/resources/swaggerTemplateOverloads/generatedAnnotation.mustache
@@ -1,0 +1,5 @@
+// For now this is a verbatim copy of
+// https://github.com/swagger-api/swagger-codegen-generators/blob/695f1cb7079b0fb4d0982e2f902dc5f59a543263/src/main/resources/handlebars/JavaSpring/generatedAnnotation.mustache
+{{^hideGenerationTimestamp}}
+@javax.annotation.Generated(value = "{{generatorClass}}", date = "{{generatedDate}}")
+{{/hideGenerationTimestamp}}

--- a/src/test/java/com/gs/crdtools/codegen/BUILD
+++ b/src/test/java/com/gs/crdtools/codegen/BUILD
@@ -6,16 +6,14 @@ java_junit5_test(
         "*Test.java",
     ]),
     deps = [
-        "//src/main/java/com/gs/crdtools:spec-extractor",
+        "//src/main/java/com/gs/crdtools/codegen:swagger-codegen-extensions",
         "//src/main/java/com/gs/crdtools:openapi-src-genner",
         "//src/main/java/com/gs/crdtools:gen-source-from-spec",
-        "//src/main/java/com/gs/crdtools/codegen:swagger-codegen-extensions",
         "@bazel_tools//tools/java/runfiles",
     ],
-    test_package = "com.gs.crdtools",
+    test_package = "com.gs.crdtools.codegen",
     size = "small",
     data = [
         "//src/test/resources:all",
     ],
 )
-

--- a/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
+++ b/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
@@ -1,0 +1,24 @@
+package com.gs.crdtools.codegen;
+
+import com.google.devtools.build.runfiles.Runfiles;
+import com.gs.crdtools.SourceGenFromSpec;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class CustomGenerationTest {
+    @Test
+    void testGenerateMinimalJava() throws IOException {
+        var runFiles = Runfiles.create();
+
+        var p = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-openapi.yaml"));
+        SourceGenFromSpec.generateSourceCodeFromSpecs(Files.readString(p), Path.of("/tmp/out.zip"));
+    }
+
+}

--- a/src/test/resources/minimal-openapi.yaml
+++ b/src/test/resources/minimal-openapi.yaml
@@ -1,0 +1,18 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Minimal openapi thing
+  license:
+    name: CC0
+paths:
+  /dummy: []
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
This change introduces functionality to override individual templates
for the code generation. In addition, it moves all the classes related
to this new functionality into the com.gs.crdtools.codegen package.