### PR TITLE
Changes to enable compliation of generated java

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,11 +41,14 @@ maven_install(
         "org.yaml:snakeyaml:1.30",
         "com.fasterxml.jackson.core:jackson-databind:2.13.3",
         "com.fasterxml.jackson.core:jackson-core:2.13.3",
+        "com.fasterxml.jackson.core:jackson-annotations:2.13.3",
         "io.swagger.codegen.v3:swagger-codegen:3.0.34",
         "io.swagger.codegen.v3:swagger-codegen-generators:1.0.34",
         "io.swagger.parser.v3:swagger-parser-v3:2.1.1",
         "io.swagger.core.v3:swagger-models:2.2.1",
         "com.github.jknack:handlebars:4.3.0",
+        "javax.validation:validation-api:2.0.1.Final",
+        "io.kubernetes:client-java-api:16.0.0",
     ],
     # The rules_jvm_external, when adding the swagger dependencies, downloads
     # a version of atlassian that comes under a different name. This is a

--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -58,14 +58,43 @@ java_binary(
     ],
 )
 
+java_binary(
+    name = "generator",
+    srcs = ["Generator.java"],
+    main_class = "com.gs.crdtools.Generator",
+    deps = [
+        ":spec-extractor",
+        ":gen-source-from-spec",
+        "//src/main/java/com/gs/crdtools/codegen:swagger-codegen-extensions",
+        "//src/main/java/com/gs/crdtools:openapi-src-genner",
+        "@maven//:io_vavr_vavr",
+        "@maven//:org_yaml_snakeyaml",
+    ],
+)
+
+
 genrule(
     name = "kcc-java-genned",
     outs = [
         "genned.srcjar",
     ],
-    visibility = ["//visibility:public"],
-    cmd = "$(location gen-source-from-spec) $(location genned.srcjar)",
-    tools = [
-        "gen-source-from-spec",
+    srcs = [
+        "//src/test/resources:crds"
     ],
+    visibility = ["//visibility:public"],
+    cmd = "$(location generator) $(location genned.srcjar) $(locations //src/test/resources:crds)",
+    tools = ["generator"],
+)
+
+java_library(
+    name = "kccapi",
+    srcs = ["kcc-java-genned"],
+    deps = [
+        ":base-object",
+        "@maven//:com_fasterxml_jackson_core_jackson_annotations",
+        "@maven//:javax_validation_validation_api",
+        "//src/main/java/org/springframework/validation/annotation:validation-stub",
+        "@maven//:io_swagger_core_v3_swagger_annotations",
+        "@maven//:io_kubernetes_client_java_api",
+    ]
 )

--- a/src/main/java/com/gs/crdtools/Generator.java
+++ b/src/main/java/com/gs/crdtools/Generator.java
@@ -1,0 +1,44 @@
+package com.gs.crdtools;
+
+import io.vavr.collection.List;
+import io.vavr.collection.Map;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static com.gs.crdtools.SourceGenFromSpec.toZip;
+
+public class Generator {
+    public static void main(String[] args) throws IOException {
+        if (args.length < 2) {
+            throw new IllegalArgumentException("Usage: Generator GENERATED_SRC_ZIP CRD_YAML [CRD_YAML...]");
+        }
+        var crds = parseCrds(List.of(args).subSequence(1).map(Path::of));
+        generate(crds, Path.of(args[0]));
+    }
+
+    private static List<Object> parseCrds(List<Path> inputs) {
+        var parser = new Yaml();
+
+        return inputs
+                .map(p -> {
+                    try {
+                        return Files.readString(p, StandardCharsets.UTF_8);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .flatMap(parser::loadAll);
+    }
+
+    private static void generate(List<Object> crds, Path output) throws IOException {
+        var specs = SourceGenFromSpec.extractSpecs(crds);
+        toZip(SourceGenFromSpec.generateSourceCodeFromSpecs(specs), output);
+    }
+
+}

--- a/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
+++ b/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
@@ -4,18 +4,25 @@ import com.gs.crdtools.codegen.CrdtoolsCodegen;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.swagger.codegen.v3.DefaultGenerator;
 import io.swagger.codegen.v3.config.CodegenConfigurator;
+import io.vavr.Tuple2;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.HashSet;
 import io.vavr.collection.List;
+import io.vavr.collection.Map;
+import io.vavr.collection.Stream;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Map;
+import java.util.Comparator;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
 
 /**
  * This class is used to generate POJO(s) from the given OpenAPIV3 specifications.
@@ -37,60 +44,109 @@ public class SourceGenFromSpec {
             List<Object> allTheYamls = SpecExtractorHelper.getCrdsYaml();
             var openApiSpecs = extractSpecs(allTheYamls);
 
-            generateSourceCodeFromSpecs(openApiSpecs, outputPath);
+            toZip(generateSourceCodeFromSpecs(openApiSpecs), outputPath);
+
         } else {
             throw new IllegalArgumentException("Invalid number of arguments. Expected 1, got " + args.length);
         }
     }
 
+    static void toZip(Map<Path, String> content, Path output) throws IOException {
+        try (var zipOutputStream = new ZipOutputStream(Files.newOutputStream(output))) {
+            for (var pathData : content) {
+                var entry = new ZipEntry(pathData._1.toString());
+                entry.setTime(0);
+                zipOutputStream.putNextEntry(entry);
+                zipOutputStream.write(pathData._2.getBytes(StandardCharsets.UTF_8));
+            }
+        }
+    }
+
+
     /**
      * Generate POJOs from a given OpenAPIV3 specification string and place them at the given path.
      * The result is a collection of jar files zipped within a .srcjar file at the path provided.
      * @param specs The OpenAPIV3 specification yaml file in the form of a string.
-     * @param out The output path.
      * @throws IOException If any error occurs while loading the given paths.
      */
-    public static void generateSourceCodeFromSpecs(String specs, Path out) throws IOException {
+    public static Map<Path, String> generateSourceCodeFromSpecs(String specs) throws IOException {
+        // setting this system property has the interesting effect of preventing the
+        // generation of a whole set of unrelated files that we don't care about.
+        System.setProperty("generateModels", "true");
+
         var tmpOutputDir = Files.createTempDirectory("openAPIGen");
 
         var cc = new CodegenConfigurator()
                 .setInputSpec(specs)
                 .setLang(CrdtoolsCodegen.class.getCanonicalName())
                 .setOutputDir(tmpOutputDir.toAbsolutePath().toString())
-                .setModelPackage("kccapi")
+                .setModelPackage("com.gs.crdtools")
                 // CodegenConfigurator modifies its Map arguments, so we need to wrap it in something mutable
-                .setAdditionalProperties(mutable(Map.of(
-                        "java8", true,
+                .setAdditionalProperties(
+                    HashMap.of(
+                        "java8", (Object)true,
                         "hideGenerationTimestamp", true,
                         "notNullJacksonAnnotation", true
-                )))
-                .setTypeMappings(mutable(Map.of(
-                        V1ObjectMeta.class.getSimpleName(), V1ObjectMeta.class.getCanonicalName()))
+                    ).toJavaMap()
+                )
+                .setTypeMappings(
+                    HashMap.of(
+                        V1ObjectMeta.class.getSimpleName(),
+                        V1ObjectMeta.class.getCanonicalName()
+                    ).toJavaMap()
                 );
+        try {
+            new DefaultGenerator().opts(cc.toClientOptInput()).generate();
+            return readDir(tmpOutputDir, ".java");
+        } finally {
+            delete(tmpOutputDir);
+        }
+    }
 
-        new DefaultGenerator().opts(cc.toClientOptInput()).generate();
-
-        SourceGeneratorHelper.writeJarToOutput(out, tmpOutputDir);
+    private static void delete(Path dir) throws IOException {
+            try (var p = Files.walk(dir)) {
+                p.sorted(Comparator.reverseOrder())
+                .forEach(f -> {
+                    try {
+                        Files.delete(f);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
     }
 
     /**
-     * Copy the keys and values from inner into a mutable Map and return it.
-     * @param inner The map to copy.
+     * Traverse all files in dir, read the contents of any file that ends with suffix and return
+     * the filenames and contents.
+     *
+     * @param dir the directory to look for files in
+     * @param suffix the suffix to match
      */
-    private static <K, V> Map<K, V> mutable(Map<K, V> inner) {
-        return new java.util.HashMap<>(inner);
-    }
+     static Map<Path, String> readDir(Path dir, String suffix) throws IOException {
+         return Stream.ofAll(Files.walk(dir))
+                 .filter(path -> path.toString().endsWith(suffix))
+                 .map(p -> {
+                     try {
+                         return new Tuple2<>(p, Files.readString(p));
+                     } catch (IOException e) {
+                         throw new RuntimeException(e);
+                     }
+                 })
+                 .map(kv -> new Tuple2<>(dir.relativize(kv._1), kv._2))
+                 .collect(HashMap.collector());
+     }
+
 
     /**
      * Extract the OpenAPIV3 specs from a list of CRDs objects extracted from a previous yaml file,
      * then returns the specs as a string.
      * @param crdsYaml The list of CRDs objects.
      */
-    private static String extractSpecs(List<Object> crdsYaml) {
-        var metadataSpec = HashMap.of("type", V1ObjectMeta.class.getSimpleName());
+    static String extractSpecs(List<Object> crdsYaml) {
 
         // Now just pull out the openapi specs
-        HashMap<Object, HashMap<String, Object>> onlySpecs = SpecExtractorHelper.pullOpenapiSpecs(crdsYaml, metadataSpec);
+        HashMap<Object, HashMap<String, Object>> onlySpecs = SpecExtractorHelper.pullOpenapiSpecs(crdsYaml);
 
         var full = HashMap.of(
                 "openapi", "3.0.0",

--- a/src/main/java/com/gs/crdtools/SourceGeneratorHelper.java
+++ b/src/main/java/com/gs/crdtools/SourceGeneratorHelper.java
@@ -26,7 +26,7 @@ public class SourceGeneratorHelper {
      * @throws RuntimeException If any issues occur while copying the content.
      */
     static void writeJarToOutput(Path out, Path outputDir) throws IOException, RuntimeException {
-        var root = outputDir.resolve("src/main/java/kccapi"); // NB: sorted for stable output
+        var root = outputDir.resolve("src/main/java/com/gs/crdtools"); // NB: sorted for stable output
 
         // try with resources is used to close the jarOut stream when the block is exited
         try (var jarOut = new JarOutputStream(Files.newOutputStream(out));

--- a/src/main/java/org/springframework/validation/annotation/BUILD
+++ b/src/main/java/org/springframework/validation/annotation/BUILD
@@ -1,0 +1,5 @@
+java_library(
+    name = "validation-stub",
+    srcs = ["Validated.java"],
+    visibility = ["//visibility:public"],
+)

--- a/src/main/java/org/springframework/validation/annotation/Validated.java
+++ b/src/main/java/org/springframework/validation/annotation/Validated.java
@@ -1,0 +1,4 @@
+package org.springframework.validation.annotation;
+
+public @interface Validated {
+}

--- a/src/main/resources/swaggerTemplateOverloads/generatedAnnotation.mustache
+++ b/src/main/resources/swaggerTemplateOverloads/generatedAnnotation.mustache
@@ -1,5 +1,5 @@
-// For now this is a verbatim copy of
-// https://github.com/swagger-api/swagger-codegen-generators/blob/695f1cb7079b0fb4d0982e2f902dc5f59a543263/src/main/resources/handlebars/JavaSpring/generatedAnnotation.mustache
+{{! For now this is a verbatim copy of
+ https://github.com/swagger-api/swagger-codegen-generators/blob/695f1cb7079b0fb4d0982e2f902dc5f59a543263/src/main/resources/handlebars/JavaSpring/generatedAnnotation.mustache }}
 {{^hideGenerationTimestamp}}
 @javax.annotation.Generated(value = "{{generatorClass}}", date = "{{generatedDate}}")
 {{/hideGenerationTimestamp}}

--- a/src/test/java/com/gs/crdtools/BUILD
+++ b/src/test/java/com/gs/crdtools/BUILD
@@ -11,6 +11,7 @@ java_junit5_test(
         "//src/main/java/com/gs/crdtools:gen-source-from-spec",
         "//src/main/java/com/gs/crdtools/codegen:swagger-codegen-extensions",
         "@bazel_tools//tools/java/runfiles",
+        "@maven//:io_vavr_vavr",
     ],
     test_package = "com.gs.crdtools",
     size = "small",

--- a/src/test/java/com/gs/crdtools/SourceGenFromSpecTest.java
+++ b/src/test/java/com/gs/crdtools/SourceGenFromSpecTest.java
@@ -1,0 +1,37 @@
+package com.gs.crdtools;
+
+import io.vavr.collection.HashMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SourceGenFromSpecTest {
+
+    @Test
+    void testReadDir(@TempDir Path temp) throws IOException {
+        // given
+        var subdir = temp.resolve("some/dir");
+        assertTrue(subdir.toFile().mkdirs());
+        Files.writeString(subdir.resolve("a.txt"), "content in a");
+        Files.writeString(subdir.resolve("b.txt"), "content in b");
+        Files.writeString(subdir.resolve("ignore"), "wrong suffix");
+
+        // when
+        var result = SourceGenFromSpec.readDir(temp, ".txt");
+
+        // when
+        assertEquals(
+            HashMap.of(
+                Path.of("some/dir/a.txt"), "content in a",
+                Path.of("some/dir/b.txt"), "content in b"
+            ),
+            result
+        );
+    }
+}

--- a/src/test/java/com/gs/crdtools/SourceGeneratorTest.java
+++ b/src/test/java/com/gs/crdtools/SourceGeneratorTest.java
@@ -1,5 +1,6 @@
 package com.gs.crdtools;
 
+import com.google.devtools.build.runfiles.Runfiles;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -9,7 +10,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import com.google.devtools.build.runfiles.Runfiles;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
+++ b/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
@@ -4,13 +4,9 @@ import com.google.devtools.build.runfiles.Runfiles;
 import com.gs.crdtools.SourceGenFromSpec;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class CustomGenerationTest {
     @Test
@@ -18,7 +14,9 @@ public class CustomGenerationTest {
         var runFiles = Runfiles.create();
 
         var p = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-openapi.yaml"));
-        SourceGenFromSpec.generateSourceCodeFromSpecs(Files.readString(p), Path.of("/tmp/out.zip"));
+        var result = SourceGenFromSpec.generateSourceCodeFromSpecs(Files.readString(p));
+
+
     }
 
 }

--- a/src/test/resources/BUILD
+++ b/src/test/resources/BUILD
@@ -1,5 +1,11 @@
 filegroup(
     name = "all",
-    srcs = glob(["*"]),
+    srcs = glob(["*.txt"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "crds",
+    srcs = glob(["*crd.yaml"]),
     visibility = ["//visibility:public"],
 )

--- a/src/test/resources/managedcertificates-crd.yaml
+++ b/src/test/resources/managedcertificates-crd.yaml
@@ -1,0 +1,179 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Copied from https://github.com/GoogleCloudPlatform/gke-managed-certs/blob/b4bbbe4cf108ab28c224b340493a58d893bdf3c6/deploy/managedcertificates-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managedcertificates.networking.gke.io
+spec:
+  group: networking.gke.io
+  versions:
+    - name: v1beta1  # (Deprecated)
+      served: true
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                certificateStatus:
+                  # The status of the managed certificate.
+                  type: string
+                domainStatus:
+                  # The status of certificate provisioning for domains
+                  # selected by the user.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - domain
+                      - status
+                    properties:
+                      domain:
+                        type: string
+                      status:
+                        type: string
+                certificateName:
+                  # The name of the provisioned managed certificate.
+                  type: string
+                expireTime:
+                  # The expire time of the provisioned managed certificate.
+                  # The certificate will be renewed automatically unless
+                  # the DNS configuration changes and prevents that.
+                  type: string
+                  format: date-time
+            spec:
+              type: object
+              properties:
+                domains:
+                  # One non-wildcard domain name up to 63 characters long.
+                  type: array
+                  maxItems: 1
+                  items:
+                    type: string
+                    maxLength: 63
+                    pattern: '^(([a-z0-9]+|[a-z0-9][-a-z0-9]*[a-z0-9])\.)+[a-z][-a-z0-9]*[a-z0-9]$'
+    - name: v1beta2  # (Deprecated)
+      served: true
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                certificateStatus:
+                  # The status of the managed certificate.
+                  type: string
+                domainStatus:
+                  # The status of certificate provisioning for domains
+                  # selected by the user.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - domain
+                      - status
+                    properties:
+                      domain:
+                        type: string
+                      status:
+                        type: string
+                certificateName:
+                  # The name of the provisioned managed certificate.
+                  type: string
+                expireTime:
+                  # The expire time of the provisioned managed certificate.
+                  # The certificate will be renewed automatically unless
+                  # the DNS configuration changes and prevents that.
+                  type: string
+                  format: date-time
+            spec:
+              type: object
+              properties:
+                domains:
+                  # Up to 100 non-wildcard domain names, each up to 63 characters long.
+                  type: array
+                  maxItems: 100
+                  items:
+                    type: string
+                    maxLength: 63
+                    pattern: '^(([a-z0-9]+|[a-z0-9][-a-z0-9]*[a-z0-9])\.)+[a-z][-a-z0-9]*[a-z0-9]$'
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                certificateStatus:
+                  # The status of the managed certificate.
+                  type: string
+                domainStatus:
+                  # The status of certificate provisioning for domains
+                  # selected by the user.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - domain
+                      - status
+                    properties:
+                      domain:
+                        type: string
+                      status:
+                        type: string
+                certificateName:
+                  # The name of the provisioned managed certificate.
+                  type: string
+                expireTime:
+                  # The expire time of the provisioned managed certificate.
+                  # The certificate will be renewed automatically unless
+                  # the DNS configuration changes and prevents that.
+                  type: string
+                  format: date-time
+            spec:
+              type: object
+              properties:
+                domains:
+                  # Up to 100 non-wildcard domain names, each up to 63 characters long.
+                  type: array
+                  maxItems: 100
+                  items:
+                    type: string
+                    maxLength: 63
+                    pattern: '^(([a-z0-9]+|[a-z0-9][-a-z0-9]*[a-z0-9])\.)+[a-z][-a-z0-9]*[a-z0-9]$'
+      additionalPrinterColumns:
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+        - name: Status
+          type: string
+          description: Status of the managed certificate
+          jsonPath: .status.certificateStatus
+  scope: Namespaced
+  names:
+    plural: managedcertificates
+    singular: managedcertificate
+    kind: ManagedCertificate
+    shortNames:
+      - mcrt

--- a/src/test/resources/minimal-crd.yaml
+++ b/src/test/resources/minimal-crd.yaml
@@ -1,0 +1,31 @@
+# copied from https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crontabs.stable.example.com
+spec:
+  group: stable.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+  scope: Namespaced
+  names:
+    plural: crontabs
+    singular: crontab
+    kind: CronTab
+    shortNames:
+      - ct


### PR DESCRIPTION
* Introduce Generator.generate() that accepts multiple crds
* Add properties apiVersion and type to generated models to enable compliation
* Move the output package com.gs.crdtools
* Have generaetSourceCodeFromSpecs return a Map<String, String> instead of
  writing to the filesystem