### PR TITLE
Changes to pick the latest cdr version when extracting openAPIV3Schema

### DIFF
--- a/src/test/java/com/gs/crdtools/SourceGenFromSpecTest.java
+++ b/src/test/java/com/gs/crdtools/SourceGenFromSpecTest.java
@@ -1,6 +1,7 @@
 package com.gs.crdtools;
 
 import io.vavr.collection.HashMap;
+import io.vavr.collection.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -10,6 +11,7 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SourceGenFromSpecTest {
 
@@ -34,4 +36,52 @@ public class SourceGenFromSpecTest {
             result
         );
     }
+
+    @Test
+    void testGetLatestVersion() {
+        // dummy versions list, schema is missing, storage is set to true
+        // if two instances of storage=true exist, the first one is returned
+        java.util.List<?> versions = List.of(
+                HashMap.of(
+                        "name", "v2",
+                        "served", true,
+                        "storage", true,
+                        "schema", (Object) "object").toJavaMap(),
+                HashMap.of(
+                        "name", "v1",
+                        "served", true,
+                        "storage", false,
+                        "schema", (Object) "object").toJavaMap(),
+                HashMap.of(
+                        "name", "v1beta1",
+                        "served", true,
+                        "storage", false,
+                        "schema", (Object) "object").toJavaMap()
+        ).toJavaList();
+
+        assertEquals(versions.get(0), SpecExtractorHelper.getLatestVersion((java.util.List<Object>) versions));
+    }
+
+    @Test
+    void testGetLatestVersionThrowsError() {
+        // dummy versions list where storage is never true
+        java.util.List<?> versions = List.of(
+                HashMap.of(
+                        "name", "v1beta1",
+                        "served", true,
+                        "storage", false,
+                        "schema", (Object) "object").toJavaMap(),
+                HashMap.of(
+                        "name", "v1",
+                        "served", true,
+                        "storage", false,
+                        "schema", (Object) "object").toJavaMap()
+        ).toJavaList();
+
+        Exception exception = assertThrows(IllegalStateException.class,
+                () -> SpecExtractorHelper.getLatestVersion((java.util.List<Object>) versions));
+
+        assertTrue(exception.getMessage().contains("No version found with storage=true"));
+    }
+
 }

--- a/src/test/resources/minimal-crd.yaml
+++ b/src/test/resources/minimal-crd.yaml
@@ -6,6 +6,20 @@ metadata:
 spec:
   group: stable.example.com
   versions:
+    - name: v1beta1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: false
+      # A schema is required
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
     - name: v1
       served: true
       storage: true


### PR DESCRIPTION
Changes:
- Added a method to extract the latest version depending on whether storage is true or false (it can only be true for one version). An error is thrown if storage is set to false for all the versions.
- Modified slightly the CronTab class to check correctness.