### PR TITLE
Return list of specs along with group and version

### DIFF
--- a/src/main/java/com/gs/crdtools/Generator.java
+++ b/src/main/java/com/gs/crdtools/Generator.java
@@ -4,14 +4,9 @@ import com.resare.nryaml.YAMLUtil;
 import com.resare.nryaml.YAMLValue;
 import io.vavr.collection.List;
 import io.vavr.collection.Map;
-import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 import static com.gs.crdtools.SourceGenFromSpec.toZip;
 
@@ -26,8 +21,6 @@ public class Generator {
     }
 
     static List<YAMLValue> parseCrds(List<Path> inputs) {
-        var parser = new Yaml();
-
         return inputs.flatMap(YAMLUtil::allFromPath);
     }
 

--- a/src/test/java/com/gs/crdtools/SourceGenFromSpecTest.java
+++ b/src/test/java/com/gs/crdtools/SourceGenFromSpecTest.java
@@ -1,6 +1,8 @@
 package com.gs.crdtools;
 
+import com.google.devtools.build.runfiles.Runfiles;
 import io.vavr.collection.HashMap;
+import io.vavr.collection.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -35,4 +37,19 @@ public class SourceGenFromSpecTest {
         );
     }
 
+    @Test
+    void testExtractSpecs() throws IOException {
+        var runFiles = Runfiles.create();
+        var input = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-crd.yaml"));
+
+        var parsedCrds = Generator.parseCrds(List.of(input));
+        var specsList = SourceGenFromSpec.extractSpecs(parsedCrds);
+
+        // there is only one crd, therefore there must be only one Spec record
+        assertEquals(1, specsList.size());
+
+        // the spec record must contain the following fields:
+        assertEquals("stable.example.com", specsList.get(0).group());
+        assertEquals("v1", specsList.get(0).version());
+    }
 }

--- a/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
+++ b/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
@@ -2,6 +2,7 @@ package com.gs.crdtools.codegen;
 
 import com.google.devtools.build.runfiles.Runfiles;
 import com.gs.crdtools.SourceGenFromSpec;
+import io.vavr.collection.List;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -14,7 +15,8 @@ public class CustomGenerationTest {
         var runFiles = Runfiles.create();
 
         var p = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-openapi.yaml"));
-        var result = SourceGenFromSpec.generateSourceCodeFromSpecs(Files.readString(p));
+        var crd = List.of(new SourceGenFromSpec.Spec("", "", Files.readString(p)));
+        var result = SourceGenFromSpec.generateSourceCodeFromSpecs(crd);
 
 
     }


### PR DESCRIPTION
This PR addresses the issue https://github.com/goldmansachs/crdtools/issues/28
More specifically:
- pullOpenApiSpecs now returns group and version as well as the kind and HashMap (as before)
- the extractSpecs method now returns List<Spec> (instead of a String) where Spec is a record containing group, version and openApi (all as strings)
- every element in List<Spec> is a fully specified crd in openapi format ready to be inputted into Swagger
- introduced some tests to check if the group and version information is stored correctly
- deleted unnecessary import statements from affected files