### PR TITLE
display group and version as annotation in the generated POJOs

### DIFF
--- a/src/main/java/com/gs/crdtools/ApiInformation.java
+++ b/src/main/java/com/gs/crdtools/ApiInformation.java
@@ -1,0 +1,13 @@
+package com.gs.crdtools;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ApiInformation {
+    public String group() default "";
+    public String version() default "";
+}

--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -6,6 +6,12 @@ java_library(
 )
 
 java_library(
+    name = "api-annotation",
+    srcs = ["ApiInformation.java"],
+    visibility = ["//visibility:public"],
+)
+
+java_library(
     name = "spec-extractor",
     visibility = ["//visibility:public"],
     srcs = ["SpecExtractorHelper.java"],

--- a/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
+++ b/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
@@ -92,7 +92,9 @@ public class SourceGenFromSpec {
                                 HashMap.of(
                                         "java8", (Object) true,
                                         "hideGenerationTimestamp", true,
-                                        "notNullJacksonAnnotation", true
+                                        "notNullJacksonAnnotation", true,
+                                        "crdGroup", spec.group(),
+                                        "crdVersion", spec.version()
                                 ).toJavaMap()
                         )
                         .setTypeMappings(

--- a/src/main/java/com/gs/crdtools/codegen/BUILD
+++ b/src/main/java/com/gs/crdtools/codegen/BUILD
@@ -9,6 +9,7 @@ java_library(
     resources = ["//src/main/resources:all"],
     deps = [
         "//src/main/java/com/gs/crdtools:base-object",
+        "//src/main/java/com/gs/crdtools:api-annotation",
         "@maven//:io_kubernetes_client_java_api",
         "@maven//:io_swagger_codegen_v3_swagger_codegen",
         "@maven//:io_swagger_codegen_v3_swagger_codegen_generators",

--- a/src/main/java/com/gs/crdtools/codegen/CrdtoolsCodegen.java
+++ b/src/main/java/com/gs/crdtools/codegen/CrdtoolsCodegen.java
@@ -3,7 +3,6 @@ package com.gs.crdtools.codegen;
 import com.gs.crdtools.BaseObject;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.swagger.codegen.v3.CodegenModel;
-import io.swagger.codegen.v3.CodegenProperty;
 import io.swagger.codegen.v3.generators.java.SpringCodegen;
 import io.swagger.v3.oas.models.media.Schema;
 import io.vavr.collection.List;
@@ -20,6 +19,7 @@ public class CrdtoolsCodegen extends SpringCodegen {
         super.processOpts();
         templateEngine = new CustomOverrideTemplateEngine(this);
         importMapping.put("BaseObject", "com.gs.crdtools.BaseObject");
+        importMapping.put("ApiInformation", "com.gs.crdtools.ApiInformation");
     }
 
     /**
@@ -35,6 +35,7 @@ public class CrdtoolsCodegen extends SpringCodegen {
         var ret = super.fromModel(name, schema, allSchemas);
 
         ret.imports.add("BaseObject");
+        ret.imports.add("ApiInformation");
 
         boolean hasMetadata = List.ofAll(ret.requiredVars)
                 .appendAll(ret.optionalVars)

--- a/src/main/resources/swaggerTemplateOverloads/generatedAnnotation.mustache
+++ b/src/main/resources/swaggerTemplateOverloads/generatedAnnotation.mustache
@@ -3,4 +3,4 @@
 {{^hideGenerationTimestamp}}
 @javax.annotation.Generated(value = "{{generatorClass}}", date = "{{generatedDate}}")
 {{/hideGenerationTimestamp}}
-// GS annotation goes here
+@ApiInformation(group = "{{crdGroup}}", version = "{{crdVersion}}")

--- a/src/test/java/com/gs/crdtools/BUILD
+++ b/src/test/java/com/gs/crdtools/BUILD
@@ -44,6 +44,7 @@ java_library(
     srcs = ["generate-java-from-crds"],
     deps = [
         "//src/main/java/com/gs/crdtools:base-object",
+        "//src/main/java/com/gs/crdtools:api-annotation",
         "@maven//:com_fasterxml_jackson_core_jackson_annotations",
         "@maven//:io_kubernetes_client_java_api",
         "@maven//:io_swagger_core_v3_swagger_annotations",


### PR DESCRIPTION
This PR now adds group and version as annotation in the generated POJOs.
An example of POJO:

```Java
/**
 * CronTab
 */
@Validated
@ApiInformation(group = "kms.cnrm.cloud.google.com", version = "v1beta1")
@JsonInclude(JsonInclude.Include.NON_NULL)

public class CronTab extends BaseObject  {
...
}
```

UnitTesting is also added to see if the annotation is actually present in the generated output.
N.B.: nryaml has been updated to the latest commit because of a problem that was present with the earlier commit version


