### PR TITLE
Make output package for generated code flexible

### DIFF
--- a/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
+++ b/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
@@ -32,6 +32,7 @@ import java.util.zip.ZipOutputStream;
  * - bazel build //:kcc_java_genned.
  */
 public class SourceGenFromSpec {
+    public static final String OUTPUT_PACKAGE = "com.gs.crdtools.generated";
 
     /**
      * Generate POJOs from the given OpenAPIV3 specifications and write them to the given path.
@@ -85,7 +86,7 @@ public class SourceGenFromSpec {
                         .setInputSpec(spec.openApiSpec())
                         .setLang(CrdtoolsCodegen.class.getCanonicalName())
                         .setOutputDir(tmpOutputDir.toAbsolutePath().toString())
-                        .setModelPackage("com.gs.crdtools")
+                        .setModelPackage(OUTPUT_PACKAGE)
                         // CodegenConfigurator modifies its Map arguments, so we need to wrap it in something mutable
                         .setAdditionalProperties(
                                 HashMap.of(

--- a/src/main/java/com/gs/crdtools/codegen/CrdtoolsCodegen.java
+++ b/src/main/java/com/gs/crdtools/codegen/CrdtoolsCodegen.java
@@ -16,6 +16,7 @@ public class CrdtoolsCodegen extends SpringCodegen {
     public void processOpts() {
         super.processOpts();
         templateEngine = new CustomOverrideTemplateEngine(this);
+        importMapping.put("BaseObject", "com.gs.crdtools.BaseObject");
     }
 
     /**
@@ -30,7 +31,7 @@ public class CrdtoolsCodegen extends SpringCodegen {
                                                         java.util.Map<String, Schema> allSchemas) {
         var ret = super.fromModel(name, schema, allSchemas);
 
-        ret.imports.add(BaseObject.class.getSimpleName());
+        ret.imports.add("BaseObject");
 
         boolean hasMetadata = List.ofAll(ret.requiredVars)
                 .appendAll(ret.optionalVars)

--- a/src/test/java/com/gs/crdtools/GeneratorTest.java
+++ b/src/test/java/com/gs/crdtools/GeneratorTest.java
@@ -8,10 +8,17 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static com.gs.crdtools.SourceGenFromSpec.OUTPUT_PACKAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GeneratorTest {
+
+    public static final Path OUTPUT_DIR = Path.of(
+            "src/main/java",
+            OUTPUT_PACKAGE.replaceAll("\\.", "/")
+    );
+
     @Test
     void testParseCrds() throws IOException {
         var runFiles = Runfiles.create();
@@ -32,9 +39,8 @@ public class GeneratorTest {
         var result = Generator.generate(Generator.parseCrds(List.of(input)));
 
         // then
-        var base = Path.of("src/main/java/com/gs/crdtools");
-        var cronTabSpec = base.resolve("CronTabSpec.java");
-        var cronTab = base.resolve("CronTab.java");
+        var cronTabSpec = OUTPUT_DIR.resolve("CronTabSpec.java");
+        var cronTab = OUTPUT_DIR.resolve("CronTab.java");
         assertEquals(HashSet.of(cronTab, cronTabSpec), result.keySet());
 
         assertTrue(result.get(cronTabSpec).get().contains("class CronTabSpec"));
@@ -51,8 +57,7 @@ public class GeneratorTest {
 
         var result = Generator.generate(Generator.parseCrds(List.of(input)));
 
-        var base = Path.of("src/main/java/com/gs/crdtools");
-        var cronTab = base.resolve("CronTab.java");
+        var cronTab = OUTPUT_DIR.resolve("CronTab.java");
 
 
         assertTrue(result.get(cronTab).get().contains("@JsonProperty(\"metadata\")"));

--- a/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
+++ b/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
@@ -10,12 +10,16 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static com.gs.crdtools.SourceGenFromSpec.OUTPUT_PACKAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CustomGenerationTest {
 
-    public static final Path OUTPUT_FILE = Path.of("src/main/java/com/gs/crdtools/Thing.java");
+    public static final Path OUTPUT_FILE = Path.of(
+            "src/main/java",
+            OUTPUT_PACKAGE.replaceAll("\\.", "/")
+    ).resolve("Thing.java");
 
     @Test
     void testGenerateMinimalJava() throws IOException {
@@ -27,6 +31,7 @@ public class CustomGenerationTest {
 
         assertEquals(HashSet.of(OUTPUT_FILE), result.keySet());
         assertTrue(result.get(OUTPUT_FILE).get().contains("GS annotation goes here"));
+        assertTrue(result.get(OUTPUT_FILE).get().contains("import com.gs.crdtools.BaseObject"));
 
     }
 


### PR DESCRIPTION
Add an import mappning for BaseObject to enable generating code
into a different package. Update the test cases to look for files
in the right output directory.