### PR TITLE
Update nryaml to the latest commit

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,7 @@ new_git_repository(
 git_repository(
     name = "nryaml",
     remote = "https://github.com/nresare/nryaml",
-    commit = "0c57aa3e0f549b96795c2af953cc98862a2df2af",
+    commit = "fba01c14d03ee24a57ddeb67b922154fa1d31401",
 )
 
 ###########################


### PR DESCRIPTION
This PR changes the commit for the dependency nryaml to the latest version. This was due to a problem with null values in YAML files.