### PR TITLE
Add test case checking the annotation generation

### DIFF
--- a/src/test/java/com/gs/crdtools/BUILD
+++ b/src/test/java/com/gs/crdtools/BUILD
@@ -25,34 +25,6 @@ java_junit5_test(
     ],
 )
 
-genrule(
-    name = "generate-java-from-crds",
-    srcs = [
-        "//src/test/resources:test_crds",
-    ],
-    outs = [
-        "generated.srcjar",
-    ],
-    cmd = """$(location //src/main/java/com/gs/crdtools:generator) \
-        $(location generated.srcjar) \
-        $(locations //src/test/resources:test_crds)""",
-    tools = ["//src/main/java/com/gs/crdtools:generator"],
-    visibility = ["//visibility:public"],
-)
-
-java_library(
-    name = "compiles-generated-java",
-    srcs = ["generate-java-from-crds"],
-    deps = [
-        "//src/main/java/com/gs/crdtools:api-annotation",
-        "//src/main/java/com/gs/crdtools:base-object",
-        "@maven//:com_fasterxml_jackson_core_jackson_annotations",
-        "@maven//:io_kubernetes_client_java_api",
-        "@maven//:io_swagger_core_v3_swagger_annotations",
-        "@maven//:javax_validation_validation_api",
-    ],
-)
-
 java_library(
     name = "result-helper",
     srcs = ["Result.java"],

--- a/src/test/java/com/gs/crdtools/codegen/BUILD
+++ b/src/test/java/com/gs/crdtools/codegen/BUILD
@@ -10,13 +10,42 @@ java_junit5_test(
         "//src/test/resources:minimal-openapi",
     ],
     test_package = "com.gs.crdtools.codegen",
-    visibility = ["//visibility:public"],
     deps = [
+        ":compiles-generated-java",
+        "//src/main/java/com/gs/crdtools:api-annotation",
         "//src/main/java/com/gs/crdtools:gen-source-from-spec",
         "//src/main/java/com/gs/crdtools:openapi-src-genner",
         "//src/main/java/com/gs/crdtools/codegen:swagger-codegen-extensions",
         "//src/test/java/com/gs/crdtools:result-helper",
         "@bazel_tools//tools/java/runfiles",
         "@maven//:io_vavr_vavr",
+    ],
+)
+
+genrule(
+    name = "generate-java-from-crds",
+    srcs = [
+        "//src/test/resources:test_crds",
+    ],
+    outs = [
+        "generated.srcjar",
+    ],
+    cmd = """$(location //src/main/java/com/gs/crdtools:generator) \
+        $(location generated.srcjar) \
+        $(locations //src/test/resources:test_crds)""",
+    tools = ["//src/main/java/com/gs/crdtools:generator"],
+    visibility = ["//visibility:public"],
+)
+
+java_library(
+    name = "compiles-generated-java",
+    srcs = [":generate-java-from-crds"],
+    deps = [
+        "//src/main/java/com/gs/crdtools:api-annotation",
+        "//src/main/java/com/gs/crdtools:base-object",
+        "@maven//:com_fasterxml_jackson_core_jackson_annotations",
+        "@maven//:io_kubernetes_client_java_api",
+        "@maven//:io_swagger_core_v3_swagger_annotations",
+        "@maven//:javax_validation_validation_api",
     ],
 )

--- a/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
+++ b/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
@@ -1,10 +1,12 @@
 package com.gs.crdtools.codegen;
 
 import com.google.devtools.build.runfiles.Runfiles;
+import com.gs.crdtools.ApiInformation;
 import com.gs.crdtools.Result;
+import com.gs.crdtools.generated.CronTab;
 import com.gs.crdtools.SourceGenFromSpec;
-import io.vavr.collection.List;
 import io.vavr.collection.HashSet;
+import io.vavr.collection.List;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -13,6 +15,7 @@ import java.nio.file.Path;
 
 import static com.gs.crdtools.SourceGenFromSpec.OUTPUT_PACKAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CustomGenerationTest {
 
@@ -32,5 +35,13 @@ public class CustomGenerationTest {
         assertEquals(HashSet.of(OUTPUT_FILE), result.inner().keySet());
         result.assertIn("Thing.java", "@ApiInformation");
         result.assertIn("Thing.java", "import com.gs.crdtools.BaseObject");
+    }
+
+    @Test
+    void testReadAnnotation() {
+        var cronTab = new CronTab();
+        var annotation = cronTab.getClass().getAnnotation(ApiInformation.class);
+        assertEquals("stable.example.com", annotation.group());
+        assertEquals("v1", annotation.version());
     }
 }


### PR DESCRIPTION
This test case verifies end-to-end that the right data is extracted
from the CRD, gets compiled into the bytecode representation of the
class and can be read at runtime