### PR TITLE
Delete old references to k8sconfigconnector

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,15 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 ## External dependencies ##
 ###########################
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
-
-new_git_repository(
-    name = "k8s-config-connector",
-    build_file_content = "exports_files(['install-bundles/install-bundle-workload-identity/crds.yaml'])",
-    commit = "1c096d9a6382fb0b6e54901e5b618f6ee9d0282b",
-    remote = "https://github.com/GoogleCloudPlatform/k8s-config-connector.git",
-    shallow_since = "",
-)
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "nryaml",

--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -19,7 +19,6 @@ java_library(
     deps = [
         "//src/main/java/com/gs/crdtools:vavr-helpers",
         "@maven//:io_vavr_vavr",
-        "@maven//:org_yaml_snakeyaml",
         "@nryaml",
     ],
 )

--- a/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
+++ b/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
@@ -1,7 +1,6 @@
 package com.gs.crdtools;
 
 import com.gs.crdtools.codegen.CrdtoolsCodegen;
-import com.resare.nryaml.YAMLUtil;
 import com.resare.nryaml.YAMLValue;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.swagger.codegen.v3.DefaultGenerator;
@@ -20,7 +19,6 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -33,26 +31,6 @@ import java.util.zip.ZipOutputStream;
  */
 public class SourceGenFromSpec {
     public static final String OUTPUT_PACKAGE = "com.gs.crdtools.generated";
-
-    /**
-     * Generate POJOs from the given OpenAPIV3 specifications and write them to the given path.
-     * @param args The genned.srcjar location, that is, the path where the generated POJOs will be written.
-     * @throws IOException If any error occurs while loading the given paths.
-     * @throws IllegalArgumentException If the number of arguments is not 1.
-     */
-    public static void main(String[] args) throws IllegalArgumentException, IOException {
-        if (args.length == 1) {
-            var outputPath = Paths.get(args[0]);
-
-            List<Object> allTheYamls = SpecExtractorHelper.getCrdsYaml();
-            var openApiSpecs = extractSpecs(allTheYamls.toStream().map(YAMLUtil::fromBare).toList());
-
-            toZip(generateSourceCodeFromSpecs(openApiSpecs), outputPath);
-
-        } else {
-            throw new IllegalArgumentException("Invalid number of arguments. Expected 1, got " + args.length);
-        }
-    }
 
     static void toZip(Map<Path, String> content, Path output) throws IOException {
         try (var zipOutputStream = new ZipOutputStream(Files.newOutputStream(output))) {

--- a/src/main/java/com/gs/crdtools/SpecExtractorHelper.java
+++ b/src/main/java/com/gs/crdtools/SpecExtractorHelper.java
@@ -6,7 +6,6 @@ import com.resare.nryaml.YAMLValue;
 import io.vavr.Tuple;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.List;
-import org.yaml.snakeyaml.Yaml;
 
 /**
  * A helper class to extract the openAPI specs from a given yaml file in the format of a string.
@@ -75,29 +74,4 @@ public class SpecExtractorHelper {
          return HashMap.of("type", qualifiedType).toJavaMap();
     }
 
-    /**
-     * Get the crds yaml file from the previously downloaded repository.
-     * This only works if the k8s-config-connector has been successfully downloaded by bazel.
-     * @return A list reflecting the content of the crds.yaml file.
-     * @throws IllegalArgumentException If the file cannot be read or the list is empty.
-     */
-    static List<Object> getCrdsYaml() throws IllegalArgumentException {
-        List<Object> allTheYamls;
-
-        try {
-            allTheYamls = List.ofAll(new Yaml().loadAll(SpecExtractorHelper.class.getResourceAsStream(
-                    "/external/k8s-config-connector/install-bundles/install-bundle-workload-identity/crds.yaml")));
-        } catch (Exception ex) {
-            // Correct exception would be IOException, but it is thrown at runtime;
-            // hence not recognised by the try block
-            throw new IllegalArgumentException("Error occurred while accessing the yaml file. " +
-                    "Has the repo been download correctly?", ex);
-        }
-
-        if (allTheYamls.isEmpty()) {
-            throw new IllegalArgumentException("Didn't find any crds?");
-        }
-
-        return allTheYamls;
-    }
 }


### PR DESCRIPTION
This PR deletes all the code that was related to k8sconfigconnector and that we do not use anymore in the attempt to make the tool a general library