### PR TITLE
Add access points in bazel BUILD file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,1 +1,11 @@
-# Temporary empty, will include access point to Generator.java in the next PR
+alias(
+    name = "generator",
+    actual = "//src/main/java/com/gs/crdtools:generator",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "runtime-dependencies",
+    actual = "//src/main/java/com/gs/crdtools:runtime-dependencies",
+    visibility = ["//visibility:public"],
+)

--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -67,3 +67,17 @@ java_binary(
         "@nryaml",
     ],
 )
+
+java_library(
+    name = "runtime-dependencies",
+    srcs = [
+        "ApiInformation.java",
+        "BaseObject.java",
+        ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":api-annotation",
+        ":base-object",
+        "@maven//:io_kubernetes_client_java_api",
+    ],
+)


### PR DESCRIPTION
By adding these two access points the tool can be used as an outside dependency to respectively:
- generate code (generator)
- compile code (crdtools)