### PR TITLE
Update build deps and remove last fragment of k8sconfigconnector

### DIFF
--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -14,10 +14,9 @@ java_library(
 java_library(
     name = "spec-extractor",
     srcs = ["SpecExtractorHelper.java"],
-    resources = ["@k8s-config-connector//:install-bundles/install-bundle-workload-identity/crds.yaml"],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/main/java/com/gs/crdtools:vavr-helpers",
+        ":vavr-helpers",
         "@maven//:io_vavr_vavr",
         "@nryaml",
     ],
@@ -42,8 +41,8 @@ java_binary(
     main_class = "com.gs.crdtools.SourceGenFromSpec",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/main/java/com/gs/crdtools:spec-extractor",
-        "//src/main/java/com/gs/crdtools:vavr-helpers",
+        ":spec-extractor",
+        ":vavr-helpers",
         "//src/main/java/com/gs/crdtools/codegen:swagger-codegen-extensions",
         "@maven//:io_kubernetes_client_java_api",
         "@maven//:io_swagger_codegen_v3_swagger_codegen",


### PR DESCRIPTION
Just realized there was one last fragment of k8s-config-connector that would cause a sync problem - that is now removed. Also, updated the dependencies to be in the format of ":name" for the ones in the same folder (so that all of them follow the same standard).