### PR TITLE
Update wrong swagger dependency

### DIFF
--- a/src/main/java/com/gs/crdtools/codegen/BUILD
+++ b/src/main/java/com/gs/crdtools/codegen/BUILD
@@ -15,7 +15,7 @@ java_library(
         "@maven//:io_swagger_codegen_v3_swagger_codegen",
         "@maven//:io_swagger_codegen_v3_swagger_codegen_generators",
         "@maven//:io_swagger_core_v3_swagger_models",
-        "@maven//:io_swagger_parser_v3_swagger_parser",
+        "@maven//:io_swagger_parser_v3_swagger_parser_v3",
         "@maven//:io_vavr_vavr",
     ],
 )


### PR DESCRIPTION
I noticed that the swagger-codegen-extensions uses the wrong version of the swagger parser (it was missing v3). I fixed that so that it doesn't cause problems with undirect dependencies when importing the project.