### PR TITLE
Incorporate a more user-friendly CLI

### DIFF
--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -61,6 +61,7 @@ java_binary(
     deps = [
         ":gen-source-from-spec",
         ":spec-extractor",
+        "//src/main/java/com/gs/crdtools:crdtools-args-parser",
         "//src/main/java/com/gs/crdtools/codegen:swagger-codegen-extensions",
         "@maven//:io_vavr_vavr",
         "@maven//:org_yaml_snakeyaml",
@@ -73,11 +74,22 @@ java_library(
     srcs = [
         "ApiInformation.java",
         "BaseObject.java",
-        ],
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":api-annotation",
         ":base-object",
         "@maven//:io_kubernetes_client_java_api",
+    ],
+)
+
+java_library(
+    name = "crdtools-args-parser",
+    srcs = [
+        "CrdToolsArgs.java",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@maven//:io_vavr_vavr",
     ],
 )

--- a/src/main/java/com/gs/crdtools/CrdToolsArgs.java
+++ b/src/main/java/com/gs/crdtools/CrdToolsArgs.java
@@ -1,0 +1,69 @@
+package com.gs.crdtools;
+
+import io.vavr.collection.List;
+
+import java.util.Arrays;
+
+/**
+ * A class listing all the possible arguments for the CRDTools tool.
+ */
+record CrdToolsArgs(List<String> crdPaths, String packageName, String outputPath) {
+
+    static final String INPUT_ARG = "-i";
+    static final String OUTPUT_ARG = "-o";
+    static final String PACKAGE_ARG = "-p";
+    public static final String DEFAULT_TARGET_PACKAGE = "com.gs.crdtools.generated";
+    public static final String DEFAULT_OUTPUT = "generated.srcjar";
+
+    /**
+     * Parse the given arguments.
+     * @param args The arguments to parse.
+     */
+    public static CrdToolsArgs parseArgs(String[] args) {
+        int parseIndex = 0;
+        List<String> crdPaths = List.empty();
+        String packageName = DEFAULT_TARGET_PACKAGE;
+        String outputPath = DEFAULT_OUTPUT;
+
+        while (hasNext(args, parseIndex) != -1) {
+            String currentArg = args[parseIndex];
+
+            switch (currentArg) {
+                case INPUT_ARG -> crdPaths = getCrdsList(args, parseIndex);
+                case PACKAGE_ARG -> packageName = args[parseIndex + 1];
+                case OUTPUT_ARG -> outputPath = args[parseIndex + 1];
+            }
+            parseIndex++;
+        }
+        return new CrdToolsArgs(crdPaths, packageName, outputPath);
+    }
+
+    /**
+     * Find the next argument in the list and return its index.
+     * Return -1 if there are no more arguments.
+     * @param args The list of arguments to search.
+     * @return The index of the next argument in the list, or -1 if none.
+     */
+    static int hasNext(String[] args, int index) {
+        int i = index + 1;
+        while (i < args.length) {
+            if (args[i].startsWith("-")) {
+                return i;
+            } else if (i == args.length - 1) {
+                return i + 1;
+            }
+            i++;
+        }
+        return -1;
+    }
+
+    /**
+     * Get the values for the input argument.
+     * @param args The list of arguments to search.
+     * @return The values for the input argument.
+     */
+    static List<String> getCrdsList(String[] args, int index) {
+        return List.of(Arrays.copyOfRange(args, index + 1, hasNext(args, index)));
+    }
+
+}

--- a/src/main/java/com/gs/crdtools/Generator.java
+++ b/src/main/java/com/gs/crdtools/Generator.java
@@ -13,20 +13,24 @@ import static com.gs.crdtools.SourceGenFromSpec.toZip;
 public class Generator {
     public static void main(String[] args) throws IOException {
         if (args.length < 2) {
-            throw new IllegalArgumentException("Usage: Generator GENERATED_SRC_ZIP CRD_YAML [CRD_YAML...]");
+            throw new IllegalArgumentException("Usage: Generator -o GENERATED_SRC_ZIP -p PACKAGE_NAME -i CRD_YAML [CRD_YAML...]");
         }
-        var crds = parseCrds(List.of(args).subSequence(1).map(Path::of));
-        var result = generate(crds);
-        toZip(result, Path.of(args[0]));
+
+        var parsed = CrdToolsArgs.parseArgs(args);
+
+        var crdsList = parseCrds(parsed.crdPaths().map(Path::of));
+        var result = generate(crdsList, parsed.packageName());
+
+        toZip(result, Path.of(parsed.outputPath()));
     }
 
     static List<YAMLValue> parseCrds(List<Path> inputs) {
         return inputs.flatMap(YAMLUtil::allFromPath);
     }
 
-    static Map<Path, String> generate(List<YAMLValue> crds) throws IOException {
+    static Map<Path, String> generate(List<YAMLValue> crds, String packageName) throws IOException {
         var specs = SourceGenFromSpec.extractSpecs(crds);
-        return SourceGenFromSpec.generateSourceCodeFromSpecs(specs);
+        return SourceGenFromSpec.generateSourceCodeFromSpecs(specs, packageName);
     }
 
 }

--- a/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
+++ b/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
@@ -30,7 +30,6 @@ import java.util.zip.ZipOutputStream;
  * - bazel build //:kcc_java_genned.
  */
 public class SourceGenFromSpec {
-    public static final String OUTPUT_PACKAGE = "com.gs.crdtools.generated";
 
     static void toZip(Map<Path, String> content, Path output) throws IOException {
         try (var zipOutputStream = new ZipOutputStream(Files.newOutputStream(output))) {
@@ -50,7 +49,7 @@ public class SourceGenFromSpec {
      * @param specs The OpenAPIV3 specification yaml file in the form of a string.
      * @throws IOException If any error occurs while loading the given paths.
      */
-    public static Map<Path, String> generateSourceCodeFromSpecs(List<Spec> specs) throws IOException {
+    public static Map<Path, String> generateSourceCodeFromSpecs(List<Spec> specs, String modelPackage) throws IOException {
         // setting this system property has the interesting effect of preventing the
         // generation of a whole set of unrelated files that we don't care about.
         System.setProperty("generateModels", "true");
@@ -64,7 +63,7 @@ public class SourceGenFromSpec {
                         .setInputSpec(spec.openApiSpec())
                         .setLang(CrdtoolsCodegen.class.getCanonicalName())
                         .setOutputDir(tmpOutputDir.toAbsolutePath().toString())
-                        .setModelPackage(OUTPUT_PACKAGE)
+                        .setModelPackage(modelPackage)
                         // CodegenConfigurator modifies its Map arguments, so we need to wrap it in something mutable
                         .setAdditionalProperties(
                                 HashMap.of(

--- a/src/main/java/com/gs/crdtools/codegen/BUILD
+++ b/src/main/java/com/gs/crdtools/codegen/BUILD
@@ -15,7 +15,7 @@ java_library(
         "@maven//:io_swagger_codegen_v3_swagger_codegen",
         "@maven//:io_swagger_codegen_v3_swagger_codegen_generators",
         "@maven//:io_swagger_core_v3_swagger_models",
-        "@maven//:io_swagger_parser_v3_swagger_parser",
+        "@maven//:io_swagger_parser_v3_swagger_parser_v3",
         "@maven//:io_vavr_vavr",
     ],
 )

--- a/src/test/java/com/gs/crdtools/BUILD
+++ b/src/test/java/com/gs/crdtools/BUILD
@@ -13,6 +13,7 @@ java_junit5_test(
     test_package = "com.gs.crdtools",
     deps = [
         ":result-helper",
+        "//src/main/java/com/gs/crdtools:crdtools-args-parser",
         "//src/main/java/com/gs/crdtools:gen-source-from-spec",
         "//src/main/java/com/gs/crdtools:generator",
         "//src/main/java/com/gs/crdtools:spec-extractor",

--- a/src/test/java/com/gs/crdtools/CrdToolsArgsTest.java
+++ b/src/test/java/com/gs/crdtools/CrdToolsArgsTest.java
@@ -1,0 +1,55 @@
+package com.gs.crdtools;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CrdToolsArgsTest {
+
+    @Test
+    void testParseArgs() {
+        var args = new String[] {"-p", "com.gs.crdtools.generated", "-o", "generated.srcjar", "-i", "example_crd_1.yaml"};
+        var result = CrdToolsArgs.parseArgs(args);
+        assertEquals("com.gs.crdtools.generated", result.packageName());
+        assertEquals("generated.srcjar", result.outputPath());
+        assertEquals(1, result.crdPaths().size());
+        assertEquals("example_crd_1.yaml", result.crdPaths().get(0));
+    }
+
+    @Test
+    void testParseMultipleInputs() {
+        var args = new String[] {"-i", "example_crd_1.yaml", "example_crd_2.yaml"};
+        var result = CrdToolsArgs.parseArgs(args);
+        assertEquals(2, result.crdPaths().size());
+        assertEquals("example_crd_1.yaml", result.crdPaths().get(0));
+        assertEquals("example_crd_2.yaml", result.crdPaths().get(1));
+    }
+
+    @Test
+    void testParseArgsWithDefault() {
+        var args = new String[] {"-i", "example_crd_1.yaml"};
+        var result = CrdToolsArgs.parseArgs(args);
+        assertEquals("com.gs.crdtools.generated", result.packageName());
+        assertEquals("generated.srcjar", result.outputPath());
+        assertEquals(1, result.crdPaths().size());
+        assertEquals("example_crd_1.yaml", result.crdPaths().get(0));
+    }
+
+    @Test
+    void testHasNextInputFirst() {
+        var args = new String[] {"-i", "example_crd_1.yaml", "example_crd_2.yaml", "-p", "this.is.a.package"};
+        assertEquals(3, CrdToolsArgs.hasNext(args, 0));
+    }
+
+    @Test
+    void testHasNextInputMiddle() {
+        var args = new String[] {"-p", "this.is.a.package", "-i", "example_crd_1.yaml", "example_crd_2.yaml", "-o", "generated.srcjar"};
+        assertEquals(5, CrdToolsArgs.hasNext(args, 2));
+    }
+
+    @Test
+    void testHasNextInputLast() {
+        var args = new String[] {"-p", "this.is.a.package", "-i", "example_crd_1.yaml", "example_crd_2.yaml"};
+        assertEquals(5, CrdToolsArgs.hasNext(args, 2));
+    }
+}

--- a/src/test/java/com/gs/crdtools/GeneratorTest.java
+++ b/src/test/java/com/gs/crdtools/GeneratorTest.java
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static com.gs.crdtools.SourceGenFromSpec.OUTPUT_PACKAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GeneratorTest {
 
+    public static final String OUTPUT_PACKAGE = "com.gs.crdtools.generated";
     public static final Path OUTPUT_DIR = Path.of(
             "src/main/java",
             OUTPUT_PACKAGE.replaceAll("\\.", "/")
@@ -35,7 +35,7 @@ public class GeneratorTest {
 
         var input = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-crd.yaml"));
         var parsedCrd = Generator.parseCrds(List.of(input));
-        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd));
+        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd, OUTPUT_PACKAGE));
 
         var cronTabSpec = OUTPUT_DIR.resolve("CronTabSpec.java");
         var cronTab = OUTPUT_DIR.resolve("CronTab.java");
@@ -51,7 +51,7 @@ public class GeneratorTest {
 
         var input = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-crd.yaml"));
         var parsedCrd = Generator.parseCrds(List.of(input));
-        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd));
+        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd, OUTPUT_PACKAGE));
 
         sourceCodeFromSpecs.assertIn("CronTab.java", "@JsonProperty(\"metadata\")");
         sourceCodeFromSpecs.assertIn("CronTab.java", "@JsonProperty(\"kind\")");
@@ -65,7 +65,7 @@ public class GeneratorTest {
 
         var input = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-crd.yaml"));
         var parsedCrd = Generator.parseCrds(List.of(input));
-        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd));
+        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd, OUTPUT_PACKAGE));
 
         sourceCodeFromSpecs.assertIn("CronTab.java", "group = \"stable.example.com\"");
         sourceCodeFromSpecs.assertIn("CronTab.java", "version = \"v1\"");

--- a/src/test/java/com/gs/crdtools/codegen/BUILD
+++ b/src/test/java/com/gs/crdtools/codegen/BUILD
@@ -30,8 +30,9 @@ genrule(
         "generated.srcjar",
     ],
     cmd = """$(location //src/main/java/com/gs/crdtools:generator) \
-        $(location generated.srcjar) \
-        $(locations //src/test/resources:test_crds)""",
+        -o $(location generated.srcjar) \
+        -i $(locations //src/test/resources:test_crds) \
+        -p com.gs.crdtools.generated""",
     tools = ["//src/main/java/com/gs/crdtools:generator"],
     visibility = ["//visibility:public"],
 )

--- a/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
+++ b/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
@@ -13,12 +13,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static com.gs.crdtools.SourceGenFromSpec.OUTPUT_PACKAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class CustomGenerationTest {
 
+    public static final String OUTPUT_PACKAGE = "com.gs.crdtools.generated";
     public static final Path OUTPUT_FILE = Path.of(
             "src/main/java",
             OUTPUT_PACKAGE.replaceAll("\\.", "/")
@@ -30,7 +30,7 @@ public class CustomGenerationTest {
 
         var p = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-openapi.yaml"));
         var crd = List.of(new SourceGenFromSpec.Spec("", "", Files.readString(p)));
-        var result = new Result(SourceGenFromSpec.generateSourceCodeFromSpecs(crd));
+        var result = new Result(SourceGenFromSpec.generateSourceCodeFromSpecs(crd, OUTPUT_PACKAGE));
 
         assertEquals(HashSet.of(OUTPUT_FILE), result.inner().keySet());
         result.assertIn("Thing.java", "@ApiInformation");


### PR DESCRIPTION
This PR adds a CLI thus allowing the user to:
- choose the output path (or if executed via bazel the name for the final .srcjar archive - this is done via -o option)
- list all of the different crds (provided they all come after the -i option)
- choose the package name (using -p option)