### PR TITLE
Incorporate a more user-friendly argsParser

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,6 +47,7 @@ maven_install(
         "com.github.jknack:handlebars:4.3.0",
         "javax.validation:validation-api:2.0.1.Final",
         "io.kubernetes:client-java-api:16.0.0",
+        "info.picocli:picocli:4.6.3",
     ],
     fetch_sources = True,
     # The rules_jvm_external, when adding the swagger dependencies, downloads

--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -52,6 +52,7 @@ java_binary(
         ":gen-source-from-spec",
         ":spec-extractor",
         "//src/main/java/com/gs/crdtools/codegen:swagger-codegen-extensions",
+        "@maven//:info_picocli_picocli",
         "@maven//:io_vavr_vavr",
         "@maven//:org_yaml_snakeyaml",
         "@nryaml",

--- a/src/main/java/com/gs/crdtools/Generator.java
+++ b/src/main/java/com/gs/crdtools/Generator.java
@@ -5,29 +5,64 @@ import com.resare.nryaml.YAMLUtil;
 import com.resare.nryaml.YAMLValue;
 import io.vavr.collection.List;
 import io.vavr.collection.Map;
+import picocli.CommandLine;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
 import static com.gs.crdtools.SourceGenFromSpec.toZip;
 
-public class Generator {
-    public static void main(String[] args) throws IOException {
-        if (args.length < 2) {
-            throw new IllegalArgumentException("Usage: Generator GENERATED_SRC_ZIP CRD_YAML [CRD_YAML...]");
+@CommandLine.Command(name = "generator", version = "crdtools 1.0", mixinStandardHelpOptions = true,
+        description = "generate one or more compile-able java classes for each set of CRDs")
+public class Generator implements Runnable {
+
+    @CommandLine.Option(names = {"-p", "--package"}, description = "Model package")
+    String targetPackage = "com.gs.crdtools.generated";
+
+    @CommandLine.Option(names = {"-o", "--out", "--output"}, description = "Output file")
+    String output = "generated.srcjar";
+
+    @CommandLine.Parameters(arity = "1..*", description = "One or more CRD(s) input")
+    String[] inputCrds;
+
+    public void run() {
+        try {
+            Generator.generateAndZip(inputCrds, targetPackage, output);
+        } catch (IOException e) {
+            throw new RuntimeException("An unexpected error occurred. " +
+                    "Make sure to follow the usage instructions for this tool.");
         }
-        var crds = parseCrds(List.of(args).subSequence(1).map(Path::of));
-        var result = generate(crds);
-        toZip(result, Path.of(args[0]));
+    }
+
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new Generator()).execute(args);
+        System.exit(exitCode);
+    }
+
+    static void generateAndZip(String[] inputCrds, String packageName, String outputPath) throws IOException {
+        var crdsList = parseCrds(List.of(inputCrds).map(Path::of));
+        var result = generate(crdsList, packageName);
+        toZip(result, Path.of(outputPath));
     }
 
     static List<YAMLMapping> parseCrds(List<Path> inputs) {
         return inputs.flatMap(YAMLUtil::allFromPath).map(YAMLValue::asMapping);
     }
 
-    static Map<Path, String> generate(List<YAMLMapping> crds) throws IOException {
+    static Map<Path, String> generate(List<YAMLMapping> crds, String packageName) throws IOException {
         var spec = SpecExtractorHelper.createSpec(crds);
-        return SourceGenFromSpec.generateSource(spec);
+        return SourceGenFromSpec.generateSource(spec, packageName);
     }
 
+    String getPackage() {
+        return this.targetPackage;
+    }
+
+    String getOutput() {
+        return this.output;
+    }
+
+    String[] getInputCdrs() {
+        return this.inputCrds;
+    }
 }

--- a/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
+++ b/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
@@ -24,7 +24,6 @@ import java.util.zip.ZipOutputStream;
  * - bazel build //:kcc_java_genned.
  */
 public class SourceGenFromSpec {
-    public static final String OUTPUT_PACKAGE = "com.gs.crdtools.generated";
 
     static void toZip(Map<Path, String> content, Path output) throws IOException {
         try (var zipOutputStream = new ZipOutputStream(Files.newOutputStream(output))) {
@@ -42,7 +41,7 @@ public class SourceGenFromSpec {
      * The result is a collection of jar files zipped within a .srcjar file at the path provided.
      * @throws IOException If any error occurs while loading the given paths.
      */
-    public static Map<Path, String> generateSource(SpecExtractorHelper.Spec spec) throws IOException {
+    public static Map<Path, String> generateSource(SpecExtractorHelper.Spec spec, String modelPackage) throws IOException {
         // setting this system property has the interesting effect of preventing the
         // generation of a whole set of unrelated files that we don't care about.
         System.setProperty("generateModels", "true");
@@ -55,7 +54,7 @@ public class SourceGenFromSpec {
                     .setInputSpec(spec.openapiSpec())
                     .setLang(CrdtoolsCodegen.class.getCanonicalName())
                     .setOutputDir(tmpOutputDir.toAbsolutePath().toString())
-                    .setModelPackage(OUTPUT_PACKAGE)
+                    .setModelPackage(modelPackage)
                     // CodegenConfigurator modifies its Map arguments, so we need to wrap it in something mutable
                     .setAdditionalProperties(
                             HashMap.of(
@@ -75,7 +74,6 @@ public class SourceGenFromSpec {
                                     "integer", "Long"
                             ).toJavaMap()
                     );
-
             new DefaultGenerator().opts(cc.toClientOptInput()).generate();
             result = result.merge(readDir(tmpOutputDir, ".java"));
         } finally {

--- a/src/test/java/com/gs/crdtools/BUILD
+++ b/src/test/java/com/gs/crdtools/BUILD
@@ -19,6 +19,7 @@ java_junit5_test(
         "//src/main/java/com/gs/crdtools/codegen:swagger-codegen-extensions",
         "@bazel_tools//tools/java/runfiles",
         "@maven//:io_vavr_vavr",
+        "@maven//:info_picocli_picocli",
         "@nryaml",
     ],
 )

--- a/src/test/java/com/gs/crdtools/GeneratorTest.java
+++ b/src/test/java/com/gs/crdtools/GeneratorTest.java
@@ -4,15 +4,19 @@ import com.google.devtools.build.runfiles.Runfiles;
 import io.vavr.collection.HashSet;
 import io.vavr.collection.List;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Path;
 
-import static com.gs.crdtools.SourceGenFromSpec.OUTPUT_PACKAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GeneratorTest {
 
+    public static final String OUTPUT_PACKAGE = "com.gs.crdtools.generated";
     public static final Path OUTPUT_DIR = Path.of(
             "src/main/java",
             OUTPUT_PACKAGE.replaceAll("\\.", "/")
@@ -35,7 +39,7 @@ public class GeneratorTest {
 
         var input = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-crd.yaml"));
         var parsedCrd = Generator.parseCrds(List.of(input));
-        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd));
+        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd, OUTPUT_PACKAGE));
 
         var cronTabSpec = OUTPUT_DIR.resolve("CronTabSpec.java");
         var cronTab = OUTPUT_DIR.resolve("CronTab.java");
@@ -46,12 +50,59 @@ public class GeneratorTest {
     }
 
     @Test
+    void testGenerateMultipleFiles() throws IOException {
+        var runFiles = Runfiles.create();
+
+        var input = List.of(
+                Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-crd.yaml")),
+                Path.of(runFiles.rlocation("__main__/src/test/resources/managedcertificates-crd.yaml"))
+        );
+        var parsedCrd = Generator.parseCrds(input);
+        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd, OUTPUT_PACKAGE));
+
+        var expectedFiles = List.of(
+                "CronTab.java",
+                "CronTabSpec.java",
+                "ManagedCertificate.java",
+                "ManagedCertificateSpec.java",
+                "ManagedCertificateStatus.java",
+                "ManagedCertificateStatusDomainStatus.java"
+        );
+        var expectedOutput = HashSet.ofAll(expectedFiles.map(OUTPUT_DIR::resolve));
+
+        assertEquals(expectedOutput, sourceCodeFromSpecs.inner().keySet());
+    }
+
+    @Test
+    void testGenerationDefaultValues() {
+        Generator generator = new Generator();
+        assertEquals(generator.getPackage(), "com.gs.crdtools.generated");
+        assertEquals(generator.getOutput(), "generated.srcjar");
+        assertNull(generator.getInputCdrs());
+    }
+
+    @Test
+    void testGenerationCustomValues() {
+        Generator generator = new Generator();
+
+        CommandLine cmd = new CommandLine(generator);
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+
+        cmd.execute("src/test/resources/minimal-crd.yaml", "-p my.test.package", "-o my-output.srcjar");
+        assertEquals(generator.getPackage().trim(), "my.test.package");
+        assertEquals(generator.getOutput().trim(), "my-output.srcjar");
+        assertEquals(generator.getInputCdrs().length, 1);
+        assertEquals(generator.getInputCdrs()[0], "src/test/resources/minimal-crd.yaml");
+    }
+
+    @Test
     void testGenerateCodeContainsAdditionalProperties() throws IOException {
         var runFiles = Runfiles.create();
 
         var input = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-crd.yaml"));
         var parsedCrd = Generator.parseCrds(List.of(input));
-        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd));
+        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd, OUTPUT_PACKAGE));
 
         sourceCodeFromSpecs.assertIn("CronTab.java", "@JsonProperty(\"metadata\")");
         sourceCodeFromSpecs.assertIn("CronTab.java", "@JsonProperty(\"kind\")");
@@ -65,7 +116,7 @@ public class GeneratorTest {
 
         var input = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-crd.yaml"));
         var parsedCrd = Generator.parseCrds(List.of(input));
-        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd));
+        var sourceCodeFromSpecs = new Result(Generator.generate(parsedCrd, OUTPUT_PACKAGE));
 
         sourceCodeFromSpecs.assertIn("CronTab.java", "group = \"stable.example.com\"");
         sourceCodeFromSpecs.assertIn("CronTab.java", "version = \"v1\"");

--- a/src/test/java/com/gs/crdtools/codegen/BUILD
+++ b/src/test/java/com/gs/crdtools/codegen/BUILD
@@ -31,8 +31,9 @@ genrule(
         "generated.srcjar",
     ],
     cmd = """$(location //src/main/java/com/gs/crdtools:generator) \
-        $(location generated.srcjar) \
-        $(locations //src/test/resources:test_crds)""",
+        $(locations //src/test/resources:test_crds) \
+        -o $(location generated.srcjar) \
+        -p com.gs.crdtools.generated""",
     tools = ["//src/main/java/com/gs/crdtools:generator"],
     visibility = ["//visibility:public"],
 )

--- a/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
+++ b/src/test/java/com/gs/crdtools/codegen/CustomGenerationTest.java
@@ -14,11 +14,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static com.gs.crdtools.SourceGenFromSpec.OUTPUT_PACKAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CustomGenerationTest {
 
+    public static final String OUTPUT_PACKAGE = "com.gs.crdtools.generated";
     public static final Path OUTPUT_FILE = Path.of(
             "src/main/java",
             OUTPUT_PACKAGE.replaceAll("\\.", "/")
@@ -30,7 +30,7 @@ public class CustomGenerationTest {
 
         var p = Path.of(runFiles.rlocation("__main__/src/test/resources/minimal-openapi.yaml"));
         var spec = new SpecExtractorHelper.Spec(Files.readString(p), HashMap.of("Thing", new SpecExtractorHelper.Metadata("group", "version")));
-        var result = new Result(SourceGenFromSpec.generateSource(spec));
+        var result = new Result(SourceGenFromSpec.generateSource(spec, OUTPUT_PACKAGE));
 
         assertEquals(HashSet.of(OUTPUT_FILE), result.inner().keySet());
         result.assertIn("Thing.java", "@ApiInformation");


### PR DESCRIPTION
Effectively the same as https://github.com/goldmansachs/crdtools/pull/53. Renaming the branch to a better name for this PR has caused the other one to close.