### PR TITLE
Add generated annotation

### DIFF
--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -2,7 +2,6 @@ java_library(
     name = "base-object",
     srcs = [
         "BaseObject.java",
-        "Generated.java",
     ],
     visibility = ["//visibility:public"],
     deps = ["@maven//:io_kubernetes_client_java_api"],
@@ -10,7 +9,10 @@ java_library(
 
 java_library(
     name = "api-annotation",
-    srcs = ["ApiInformation.java"],
+    srcs = [
+        "ApiInformation.java", 
+        "Generated.java",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -1,6 +1,9 @@
 java_library(
     name = "base-object",
-    srcs = ["BaseObject.java"],
+    srcs = [
+        "BaseObject.java",
+        "Generated.java",
+    ],
     visibility = ["//visibility:public"],
     deps = ["@maven//:io_kubernetes_client_java_api"],
 )

--- a/src/main/java/com/gs/crdtools/BaseObject.java
+++ b/src/main/java/com/gs/crdtools/BaseObject.java
@@ -2,5 +2,6 @@ package com.gs.crdtools;
 
 import io.kubernetes.client.common.KubernetesObject;
 
+@Generated
 public abstract class BaseObject implements KubernetesObject {
 }

--- a/src/main/java/com/gs/crdtools/BaseObject.java
+++ b/src/main/java/com/gs/crdtools/BaseObject.java
@@ -2,6 +2,5 @@ package com.gs.crdtools;
 
 import io.kubernetes.client.common.KubernetesObject;
 
-@Generated
 public abstract class BaseObject implements KubernetesObject {
 }

--- a/src/main/java/com/gs/crdtools/CrdtoolsCodegen.java
+++ b/src/main/java/com/gs/crdtools/CrdtoolsCodegen.java
@@ -23,6 +23,7 @@ public class CrdtoolsCodegen extends SpringCodegen {
         templateEngine = new CustomOverrideTemplateEngine(this);
         importMapping.put("BaseObject", "com.gs.crdtools.BaseObject");
         importMapping.put("ApiInformation", "com.gs.crdtools.ApiInformation");
+        importMapping.put("Generated", "com.gs.crdtools.Generated");
     }
 
     @SuppressWarnings("unchecked")
@@ -56,6 +57,7 @@ public class CrdtoolsCodegen extends SpringCodegen {
 
         ret.imports.add("BaseObject");
         ret.imports.add("ApiInformation");
+        ret.imports.add("Generated")
 
         boolean hasMetadata = List.ofAll(ret.requiredVars)
                 .appendAll(ret.optionalVars)

--- a/src/main/java/com/gs/crdtools/CrdtoolsCodegen.java
+++ b/src/main/java/com/gs/crdtools/CrdtoolsCodegen.java
@@ -57,7 +57,7 @@ public class CrdtoolsCodegen extends SpringCodegen {
 
         ret.imports.add("BaseObject");
         ret.imports.add("ApiInformation");
-        ret.imports.add("Generated")
+        ret.imports.add("Generated");
 
         boolean hasMetadata = List.ofAll(ret.requiredVars)
                 .appendAll(ret.optionalVars)

--- a/src/main/java/com/gs/crdtools/Generated.java
+++ b/src/main/java/com/gs/crdtools/Generated.java
@@ -1,0 +1,11 @@
+package com.gs.crdtools;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Generated {
+
+}

--- a/src/main/resources/swaggerTemplateOverloads/generatedAnnotation.mustache
+++ b/src/main/resources/swaggerTemplateOverloads/generatedAnnotation.mustache
@@ -4,3 +4,4 @@
 @javax.annotation.Generated(value = "{{generatorClass}}", date = "{{generatedDate}}")
 {{/hideGenerationTimestamp}}
 @ApiInformation(group = "{{crdGroup}}", version = "{{crdVersion}}")
+@Generated


### PR DESCRIPTION
Jacoco has a facility to exclude generated code from coverage reports. To take advantage, the annotation must be called ‘Generated’, must be visible at compile time, and must be directly on the class itself (I.e. not @Inherited). This adds such an annotation. 